### PR TITLE
package.json ENOENT error

### DIFF
--- a/bin/store.js
+++ b/bin/store.js
@@ -1,5 +1,9 @@
 import fs from 'fs'
 import Configstore from 'configstore';
-const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
+import path from 'path'
+import { fileURLToPath }  from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname,'../package.json'), 'utf8'));
 
 export const store = new Configstore(packageJson.name, {init: true})


### PR DESCRIPTION
### Issue:

#2 

### Resolution and Explanation:

The problem with using `./package.json` is that it tries to search in the local directory from which the command `jsexplorer` is run. 

In order to make it relative across operating systems and filesystems, using the global node variable of `__dirname` can be useful.

`__dirname` is not available in the command line environment since it is a global variable in the `node` environment

In order to introduce the `__dirname` we use a simple path mixin method `fileURLToPath` to generate local `dirname` from the `ImportMetaUrl` global environment variable

