### PR TITLE
fix: prototype attribute name (property map of undefined)

### DIFF
--- a/bin/objectMethod.js
+++ b/bin/objectMethod.js
@@ -306,7 +306,7 @@ console.log(obj.d.toLocaleString());`,
       },
     ],
   },
-  prototype: [
+  managePrototypes: [
     {
       name: 'getPrototypeOf',
       shortDesc: `get a prototype of the object.`,

--- a/bin/questions.js
+++ b/bin/questions.js
@@ -87,7 +87,7 @@ const questions = [
     obj,
     'objBasis'
   ),
-  createAnswers('prototype', 'manage prototypes', obj, 'objBasis'),
+  createAnswers('managePrototypes', 'manage prototypes', obj, 'objBasis'),
   //objects with details, which is nested
   createAnswers(
     'details',


### PR DESCRIPTION
`prototype` name caused a `TypeError: Cannot read property 'map' of undefined` when selecting a `manage prototypes` help page

just edited the attribute name to fix the bug :+1: 